### PR TITLE
Allow tagging based on git sha of HEAD in kubernetes repo

### DIFF
--- a/hyperkube/Makefile
+++ b/hyperkube/Makefile
@@ -15,23 +15,22 @@ DOCKER_REPO ?= $(DEFAULT_REPO)
 #DOCKER_REPO ?= quay.io/mikeln
 DOCKER_REPO_ESC := $(subst /,\/,$(DOCKER_REPO))
 
-# this picks up the latest VERSION.  You can simply
-# hard code it if you want to build an older one:
-# V=v0.18.2 for example
-#V ?= $(shell wget -q -O- https://storage.googleapis.com/kubernetes-release/release/latest.txt)
-# the version is used to checkout from the kubernetes repo
-DEFAULT_V := unknown
-V ?= unknown
-#V ?= v1.0.1
-
-# relative to the cluster directory.  specific files are plucked from there.
-# if your git checkout of kubernetes is not in ../../kubernetes,
-# then set the variable KUBEROOT
+# kubernetes source code location, relative to the cluster directory
+# eg: KUBEROOT=$GOPATH/src/k8s.io/kubernetes
 KUBEROOT ?= ../../kubernetes
 K=${KUBEROOT}/cluster
 
-H=hyperkube
-IMAGENAME = ${DOCKER_REPO}/$H
+# kubernetes version
+# eg: V ?= $(shell wget -q -O- https://storage.googleapis.com/kubernetes-release/release/latest.txt)
+DEFAULT_V := unknown
+V ?= $(DEFAULT_V)
+# allow VERSION=sha to use the git sha of HEAD in KUBEROOT
+ifeq ($(V), sha)
+	V := $(shell cd $(KUBEROOT) && git log -n1 --format='%h')
+endif
+
+BINARY=hyperkube
+IMAGENAME = ${DOCKER_REPO}/$(BINARY)
 
 repo-warning:
 	@if  [ $(DOCKER_REPO) =  $(DEFAULT_REPO) ]; then \
@@ -60,32 +59,32 @@ repo-warning:
 		fi \
 	fi
 
-all: $(H)
+all: $(BINARY)
 
 
-$(H): $(H).tmp master-multi.json.build master.json.build safe_format_and_mount.build Dockerfile
+$(BINARY): $(BINARY).tmp master-multi.json.build master.json.build safe_format_and_mount.build Dockerfile
 	@echo "building app $(VERSION)"
 	docker build -t $(IMAGENAME):$(V) --rm=true --force-rm=true .
 	@touch $@
 	@docker images $(IMAGENAME)
 
-$(H).tmp: $(KUBEROOT)/_output/dockerized/bin/linux/amd64/$H
-	cp $(KUBEROOT)/_output/dockerized/bin/linux/amd64/$H $H.tmp
+$(BINARY).tmp: $(KUBEROOT)/_output/dockerized/bin/linux/amd64/$(BINARY)
+	cp $(KUBEROOT)/_output/dockerized/bin/linux/amd64/$(BINARY) $(BINARY).tmp
 
-master-multi.json.build: master-multi.json $(H).tmp
+master-multi.json.build: master-multi.json $(BINARY).tmp
 	#sed -e "s/VERSION/$V/g" -e "s/gcr.io\/google_containers/$(DOCKER_REPO_ESC)/g" $K/images/hyperkube/master-multi.json > master-multi.json.tmp
 	sed -e "s/VERSION/${V}/g" -e "s/REPO/${DOCKER_REPO_ESC}/g" master-multi.json > master-multi.json.build
 
-master.json.build: master.json $(H).tmp
+master.json.build: master.json $(BINARY).tmp
 	#sed -e "s/VERSION/$V/g" -e "s/gcr.io\/google_containers/$(DOCKER_REPO_ESC)/g" $K/images/hyperkube/master.json > master.json.tmp
 	sed -e "s/VERSION/${V}/g" -e "s/REPO/${DOCKER_REPO_ESC}/g" master.json > master.json.build
 
-safe_format_and_mount.build: $(H).tmp
+safe_format_and_mount.build: $(BINARY).tmp
 	#cp $K/saltbase/salt/helpers/safe_format_and_mount safe_format_and_mount.tmp
 	cp $K/saltbase/salt/helpers/safe_format_and_mount safe_format_and_mount.build
 
 
-$(KUBEROOT)/_output/dockerized/bin/linux/amd64/$H :
+$(KUBEROOT)/_output/dockerized/bin/linux/amd64/$(BINARY) :
 	(cd $(KUBEROOT)/build; ./run.sh hack/build-go.sh )
 #	(cd $(KUBEROOT)/build; ./run.sh hack/build-cross.sh )
 	#(cd $(KUBEROOT); make )
@@ -98,6 +97,6 @@ clean-all: clean
 
 clean:
 	-docker rmi $(IMAGENAME):$(V)
-	-rm -f *.tmp *.build *.src $(H)
+	-rm -f *.tmp *.build *.src $(BINARY)
 
 


### PR DESCRIPTION
invoke eg:

``` sh
  DOCKER_REPO=quay.io/spiffxp \
  KUBEROOT=$GOPATH/src/k8s.io/kubernetes \
  V=sha \
  make clean all push
```

result eg:

``` sh
  quay.io/spiffxp/hyperkube:85ee11a
```
